### PR TITLE
Improve usability of list_cluster and create_cluster

### DIFF
--- a/pydataproc/dataproc.py
+++ b/pydataproc/dataproc.py
@@ -180,6 +180,8 @@ class DataProc(object):
             clusterName=cluster_name).execute()
         return result
 
+    # TODO improve job submission - make it easier to specify jobs
+    # without needing to create a large job_details dict
     def submit_job(self, job_details):
         """
         Submit a job to a cluster.

--- a/pydataproc/dataproc.py
+++ b/pydataproc/dataproc.py
@@ -50,6 +50,21 @@ class DataProc(object):
 
         return None
 
+    def cluster_info(self, cluster_name):
+        """
+        Returns the full cluster information associated with a given
+        cluster. If the cluster does not exist, returns None.
+
+        :param cluster_name: The name of the cluster to check
+        :return: dict of cluster information, or None if no such cluster
+        """
+        clusters = self.list_clusters()
+        for c in clusters['clusters']:
+            if cluster_name == c['clusterName']:
+                return c
+
+        return None
+
     def cluster_bucket(self, cluster_name):
         """
         Returns the staging GCS bucket associated with the provided

--- a/pydataproc/dataproc.py
+++ b/pydataproc/dataproc.py
@@ -65,17 +65,23 @@ class DataProc(object):
 
         return None
 
-    def list_clusters(self):
+    def list_clusters(self, minimal=True):
         """
-        Queries the DataProc API, returning a list of all currently active clusters,
-        with all available details/configuration.
+        Queries the DataProc API, returning a dict of all currently active clusters,
+        keyed by cluster name.
 
+        If 'minimal' is specified, each cluster's current state will be returned,
+        otherwise the full cluster configuration will be returned.
+
+        :param minimal: reduces
         :return: list of dicts of cluster configuration
         """
         result = self.dataproc.projects().regions().clusters().list(
             projectId=self.project,
             region=self.region).execute()
-        return result
+        if minimal:
+            return {c['clusterName']: c['status']['state'] for c in result.get('clusters', [])}
+        return {c['clusterName']: c for c in result.get('clusters', [])}
 
     # TODO add support for preemptible workers
     def create_cluster(self, cluster_name, num_masters=1, num_workers=2,

--- a/pydataproc/dataproc.py
+++ b/pydataproc/dataproc.py
@@ -43,10 +43,9 @@ class DataProc(object):
         :param cluster_name: The name of the cluster to check
         :return: cluster state string, or None if no such cluster
         """
-        clusters = self.list_clusters()
-        for c in clusters['clusters']:
-            if cluster_name == c['clusterName']:
-                return c['status']['state']
+        for c, st in self.list_clusters().items():
+            if c == cluster_name:
+                return st
 
         return None
 
@@ -58,10 +57,9 @@ class DataProc(object):
         :param cluster_name: The name of the cluster to check
         :return: dict of cluster information, or None if no such cluster
         """
-        clusters = self.list_clusters()
-        for c in clusters['clusters']:
-            if cluster_name == c['clusterName']:
-                return c
+        for c, ci in self.list_clusters(minimal=False).items():
+            if c == cluster_name:
+                return ci
 
         return None
 
@@ -73,10 +71,9 @@ class DataProc(object):
         :param cluster_name: The name of the cluster to check
         :return: staging bucket, or None if no such cluster
         """
-        clusters = self.list_clusters()
-        for c in clusters['clusters']:
-            if cluster_name == c['clusterName']:
-                return c['config']['configBucket']
+        for c, ci in self.list_clusters(minimal=False):
+            if c == cluster_name:
+                return ci['config']['configBucket']
 
         return None
 

--- a/pydataproc/dataproc.py
+++ b/pydataproc/dataproc.py
@@ -164,7 +164,7 @@ class DataProc(object):
             time.sleep(5)
             is_running = self.dataproc.is_running(cluster_name)
 
-        return result
+        return self.cluster_info(cluster_name)
 
     def delete_cluster(self, cluster_name):
         """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ test_requires = [
 
 setup(
     name='Py-DataProc',
-    version='0.1.0',
+    version='0.2.0',
     author='Oli Hall',
     author_email='',
     description="Python wrapper for the Google DataProc client",


### PR DESCRIPTION
The main user-facing changes:
 - `list_clusters` now returns a dict of cluster_name -> cluster_information
 - `list_cluster` now has a `minimal` flag, which defaults to `True`. If this is `True`, the method returns only the state of each cluster as a string, e.g.
```bash
> dataproc.list_clusters(minimal=True)
{
    "my_cluster": "RUNNING",
    "my_new_cluster": "CREATING"
}
```
If the flag is set to `False`, the full cluster information dict will be returned against the cluster name:
```bash
> dataproc.list_clusters(minimal=False)
{
    "my_cluster": {
        # full nested cluster information here
    }
}
```
 - `create_cluster` now takes a `block` flag (defaulting to `True`), that will block returning until the cluster reaches the `RUNNING` state. This currently may have issues with clusters that fail to initialise, so use with caution if you're not 100% on the validity of your init scripts! (I'll look to add a timeout/better error handling for this soon).

The other changes here are internal, updating methods that used the existing `list_clusters` method.