### PR TITLE
Add cluster worker count update

### DIFF
--- a/pydataproc/logger.py
+++ b/pydataproc/logger.py
@@ -5,6 +5,6 @@ import sys
 log = logging.getLogger(__name__)
 log.setLevel('INFO')
 handler = logging.StreamHandler(stream=sys.stderr)
-handler.setFormatter(logging.Formatter(fmt='%(asctime)s %(levelname)s %(name)s %(message)s',
+handler.setFormatter(logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s',
                                        datefmt='%Y-%m-%d %H:%M:%S'))
 log.addHandler(handler)


### PR DESCRIPTION
Adds ability to alter the worker count of a running cluster.

There has also been a minor tweak to the log pattern, removing the package name, which was not useful given it was always the loggers' package.